### PR TITLE
Remove hardcoded java oracle binary paths, default is linked

### DIFF
--- a/group_vars/all/iri.yml
+++ b/group_vars/all/iri.yml
@@ -1,15 +1,3 @@
-# Java version to install CentOS/Redhat
-java_version: 1.8.0
-
-# For ubuntu/debian
-openjdk_version: 8
-
-# Oracle java binary location
-oracle_java_bin_ubuntu: /usr/bin/java
-
-# Oracle java binary location CentOS/RH
-oracle_java_bin_centos: /usr/java/jdk1.8.0_152/bin/java
-
 # Unprivileged user to run iri with
 iri_username: iri
 

--- a/roles/iri/templates/iri.service.j2
+++ b/roles/iri/templates/iri.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 [Service]
 WorkingDirectory={{ iri_basedir }}/target
 EnvironmentFile=-{{ config_dir }}/iri
-ExecStart={% if ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu' %}{{ oracle_java_bin_ubuntu }}{% elif ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux' %}{{ oracle_java_bin_centos }}{% else %}/usr/bin/java{% endif %} -Xmx${JAVA_MEM} -jar iri-${IRI_VERSION}.jar -c ${IRI_CONFIG_FILE} -p ${IRI_API_PORT} -u ${IRI_UDP_PORT} -t ${IRI_TCP_PORT} -n "${IRI_NEIGHBORS}" --remote-limit-api "${REMOTE_LIMIT_API}" $OPTIONS
+ExecStart=/usr/bin/java -Xmx${JAVA_MEM} -jar iri-${IRI_VERSION}.jar -c ${IRI_CONFIG_FILE} -p ${IRI_API_PORT} -u ${IRI_UDP_PORT} -t ${IRI_TCP_PORT} -n "${IRI_NEIGHBORS}" --remote-limit-api "${REMOTE_LIMIT_API}" $OPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
There was no need to set hard coded paths to java binary, it is already linked to /usr/bin/java by the installations of oracle java