### PR TITLE
Make it possible to tag an entire role

### DIFF
--- a/roles/iotapm/tasks/main.yml
+++ b/roles/iotapm/tasks/main.yml
@@ -1,11 +1,3 @@
-- import_tasks: deps.yml
+- import_tasks: role.yml
   tags:
-    - iotapm_deps
-
-- import_tasks: firewall.yml
-  tags:
-    - iotapm_firewall
-
-- import_tasks: iotapm.yml
-  tags:
-    - iotapm_config
+    - iotapm_role

--- a/roles/iotapm/tasks/role.yml
+++ b/roles/iotapm/tasks/role.yml
@@ -1,0 +1,11 @@
+- import_tasks: deps.yml
+  tags:
+    - iotapm_deps
+
+- import_tasks: firewall.yml
+  tags:
+    - iotapm_firewall
+
+- import_tasks: iotapm.yml
+  tags:
+    - iotapm_config

--- a/roles/iri/tasks/main.yml
+++ b/roles/iri/tasks/main.yml
@@ -1,23 +1,3 @@
-- import_tasks: deps_apt.yml
+- import_tasks: role.yml
   tags:
-    - iri_deps_apt
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
-
-- import_tasks: deps_yum.yml
-  tags:
-    - iri_deps_yum
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- import_tasks: firewalld.yml
-  tags:
-    - iri_firewalld
-  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
-
-- import_tasks: ufw.yml
-  tags:
-    - iri_ufw
-  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
-
-- import_tasks: iri.yml
-  tags:
-    - iri_config
+    - iri_role

--- a/roles/iri/tasks/role.yml
+++ b/roles/iri/tasks/role.yml
@@ -1,0 +1,23 @@
+- import_tasks: deps_apt.yml
+  tags:
+    - iri_deps_apt
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- import_tasks: deps_yum.yml
+  tags:
+    - iri_deps_yum
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
+- import_tasks: firewalld.yml
+  tags:
+    - iri_firewalld
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
+
+- import_tasks: ufw.yml
+  tags:
+    - iri_ufw
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+- import_tasks: iri.yml
+  tags:
+    - iri_config

--- a/roles/monitoring/role.yml
+++ b/roles/monitoring/role.yml
@@ -1,0 +1,23 @@
+- import_tasks: deps.yml
+  tags:
+    - monitoring_deps
+
+- import_tasks: firewall.yml
+  tags:
+    - monitoring_firewall
+
+- import_tasks: prometheus.yml
+  tags:
+    - prometheus_config
+
+- import_tasks: node_exporter.yml
+  tags:
+    - node_exporter_config
+
+- import_tasks: grafana.yml
+  tags:
+    - grafana_config
+
+- import_tasks: iota-prom-exporter.yml
+  tags:
+    - iota_prom_exporter

--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,23 +1,3 @@
-- import_tasks: deps.yml
+- import_tasks: role.yml
   tags:
-    - monitoring_deps
-
-- import_tasks: firewall.yml
-  tags:
-    - monitoring_firewall
-
-- import_tasks: prometheus.yml
-  tags:
-    - prometheus_config
-
-- import_tasks: node_exporter.yml
-  tags:
-    - node_exporter_config
-
-- import_tasks: grafana.yml
-  tags:
-    - grafana_config
-
-- import_tasks: iota-prom-exporter.yml
-  tags:
-    - iota_prom_exporter
+    - monitoring_role


### PR DESCRIPTION
This allows to tag an entire role when running the playbook, making the playbook much more flexible by being able to decide what to install/reinstall/upgrade.