### PR TITLE
Fix/ne fs

### DIFF
--- a/roles/monitoring/tasks/node_exporter.yml
+++ b/roles/monitoring/tasks/node_exporter.yml
@@ -6,7 +6,7 @@
     group: "{{ prom_username }}"
     recurse: yes
 
-- name: copy exporter  systemd service file
+- name: copy exporter systemd service file
   template:
     src: templates/node-exporter.service.j2
     dest: /etc/systemd/system/node-exporter.service

--- a/roles/monitoring/templates/node-exporter.service.j2
+++ b/roles/monitoring/templates/node-exporter.service.j2
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 WorkingDirectory={{ exporter_basedir }}
 Restart=on-failure
-ExecStart={{ exporter_basedir }}/node_exporter --web.listen-address={{ exporter_bind_address }}:{{ exporter_port }}
+ExecStart={{ exporter_basedir }}/node_exporter --web.listen-address={{ exporter_bind_address }}:{{ exporter_port }} --collector.filesystem.ignored-mount-points="^/(sys|proc|dev|run)($|/)"
 Type=simple
 
 # No need that exporter messes with /dev


### PR DESCRIPTION
Seeing these errors related to node_exporter:
```
Dec 20 11:07:29 localhost node_exporter: time="2017-12-20T11:07:29-08:00" level=error msg="Error on statfs() system call for \"/run/user/0\": permission denied" 
```
This commit adds mount points which node_exporter should ignore.
Given it is running as unprivileged user it doesn't have access to all fs.
These mounts are not necessary for monitoring anyway.