### PR TITLE
Add/prom iri restart

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -335,3 +335,32 @@ Edit the file ``/etc/prometheus/alert.rules.yml``, find the alert definition::
 The line that denotes the time: ``increase(iota_node_info_latest_subtangle_milestone[30m]) == 0`` -- here you can replace the ``30m`` with any other value in the same format (e.g. ``1h``, ``15m`` etc...)
 
 If any changes to this file, remember to restart prometheus: ``systemctl restart prometheus``
+
+
+Upgrading the Playbook to Get the Feature
+-----------------------------------------
+
+If you installed the playbook before this feature was release you can still install it.
+
+1. Enter the iri-playbook directory and pull new changes:
+
+.. code:: bash
+
+   cd /opt/iri-playbook && git pull
+
+If this command breaks, it means that you have conflicting changes in one of the configuration files. Try to identify those manually, create a backup of those files if required, revert and re-run the above command (or hit me up on slack or github for assitance)
+
+2. WARNING, this will overwrite changes to your monitoring configuration files if you had any manually applied! Run the playbook's monitoring role:
+
+.. code:: bash
+
+   ansible-playbook -i inventory -v site.yml --tags=monitoring_role -e overwrite=true
+
+3. **If** the playbook fails with 401 authorization error (probably when trying to run prometheus grafana datasource), you will have to re-run the command and supply your web-authentication password together with the command:
+
+.. code:: bash
+
+   ansible-playbook -i inventory -v site.yml --tags=monitoring_role -e overwrite=true -e iotapm_nginx_password="mypassword"
+
+
+

--- a/group_vars/all/iotapm.yml
+++ b/group_vars/all/iotapm.yml
@@ -18,7 +18,7 @@ iotapm_nginx_user: iotapm
 # The password to use when accessing iota-pm
 # through the webserver
 # PLEASE CHANGE THIS BEFORE INSTALLATION!!!
-iotapm_nginx_password: 'AllTangle81'
+iotapm_nginx_password: 'hello123'
 
 # If setting `iotapm_bind_address` to anything other than
 # localhost (127.0.0.1) should the port be opened in firewall

--- a/group_vars/all/iotapm.yml
+++ b/group_vars/all/iotapm.yml
@@ -18,7 +18,7 @@ iotapm_nginx_user: iotapm
 # The password to use when accessing iota-pm
 # through the webserver
 # PLEASE CHANGE THIS BEFORE INSTALLATION!!!
-iotapm_nginx_password: 'hello123'
+iotapm_nginx_password: 'AllTangle81'
 
 # If setting `iotapm_bind_address` to anything other than
 # localhost (127.0.0.1) should the port be opened in firewall

--- a/group_vars/all/monitoring.yml
+++ b/group_vars/all/monitoring.yml
@@ -28,3 +28,5 @@ alertmanager_email_to: root@localhost
 alertmanager_loglevel: info
 smtp_host: localhost
 smtp_port: 25
+
+prom_am_executor_port: 9158

--- a/roles/monitoring/files/alert.rules.yml
+++ b/roles/monitoring/files/alert.rules.yml
@@ -231,3 +231,14 @@ groups:
     annotations:
       description: 'Rate of metric not available {{ $value }}'
       summary: 'Rate of metrics is 0, IRI instance down?'
+
+  # If latest subtangle milestone doesn't increase for 30 minutes
+  - alert: MileStoneNoIncrease
+    expr: increase(iota_node_info_latest_subtangle_milestone[30m]) == 0
+      and iota_node_info_latest_subtangle_milestone != 243000
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: 'Latest Subtangle Milestone increase is {{ $value }}'
+      summary: 'Latest Subtangle Milestone not increasing'

--- a/roles/monitoring/files/restart_iri.sh
+++ b/roles/monitoring/files/restart_iri.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+/bin/systemctl restart iri

--- a/roles/monitoring/handlers/main.yml
+++ b/roles/monitoring/handlers/main.yml
@@ -21,3 +21,9 @@
     name: iota-prom-exporter.service
     state: restarted
     enabled: yes
+
+- name: restart prom-am-executor
+  systemd:
+    name: prom-am-executor.service
+    state: restarted
+    enabled: yes

--- a/roles/monitoring/tasks/prom-am-executor.yml
+++ b/roles/monitoring/tasks/prom-am-executor.yml
@@ -18,8 +18,8 @@
   notify:
     - reload systemd
 
-- name: ensure prometheus enabled and started
+- name: ensure prom-am-executor enabled and started
   systemd:
-    name: prometheus.service
+    name: prom-am-executor.service
     state: started
     enabled: yes

--- a/roles/monitoring/tasks/prom-am-executor.yml
+++ b/roles/monitoring/tasks/prom-am-executor.yml
@@ -1,0 +1,24 @@
+- name: copy prometheus alertmanager executor binary
+  copy:
+    src: files/prom-am-executor
+    dest: "{{ prom_basedir }}/prom-am-executor"
+    mode: 0700
+
+- name: copy iri restart script
+  copy:
+    src: files/restart_iri.sh
+    dest: "{{ prom_basedir }}/restart_iri.sh"
+    mode: 0700
+  
+- name: copy prometheus alertmanager executor service file
+  template:
+    src: templates/prom-am-executor.service.j2
+    dest: /etc/systemd/system/prom-am-executor.service
+  notify:
+    - reload systemd
+
+- name: ensure prometheus enabled and started
+  systemd:
+    name: prometheus.service
+    state: started
+    enabled: yes

--- a/roles/monitoring/tasks/prom-am-executor.yml
+++ b/roles/monitoring/tasks/prom-am-executor.yml
@@ -1,3 +1,4 @@
+# Executor credits go to https://github.com/imgix/prometheus-am-executor
 - name: copy prometheus alertmanager executor binary
   copy:
     src: files/prom-am-executor

--- a/roles/monitoring/tasks/role.yml
+++ b/roles/monitoring/tasks/role.yml
@@ -25,3 +25,7 @@
 - import_tasks: iota-prom-exporter.yml
   tags:
     - iota_prom_exporter
+
+- import_tasks: prom-am-executor.yml
+  tags:
+    - prom_am_executor

--- a/roles/monitoring/templates/alertmanager.cfg.yml.j2
+++ b/roles/monitoring/templates/alertmanager.cfg.yml.j2
@@ -14,10 +14,22 @@ route:
   group_by: [Alertname]
   repeat_interval: 1h
   receiver: email-me
+
+# Uncomment these lines to enable webhook executor to restart iri
+# when subtangle milestone stuck:
+
+#  routes:
+#  - receiver: 'executor'
+#    match:
+#      alertname: MileStoneNoIncrease
+
+
+
+# Templates directory
 templates:
   - {{ alertmanager_basedir }}/template/*.tmpl
-receivers:
 
+receivers:
 # Send using postfix local mailer
 # You can send to a gmail or hotmail address
 # but these will most probably be put into junkmail
@@ -30,6 +42,10 @@ receivers:
 
     smarthost: {{ smtp_host }}:{{ smtp_port }}
     send_resolved: true
+
+- name: executor
+  webhook_configs:
+  - url: http://localhost:{{ prom_am_executor_port }}
 
 # For gmail, replace the variables/placeholders with your data
 #- name: email-me

--- a/roles/monitoring/templates/prom-am-executor.service.j2
+++ b/roles/monitoring/templates/prom-am-executor.service.j2
@@ -1,0 +1,32 @@
+[Unit]
+Description=Restart IRI Executor For Prometheus
+Wants=network-online.target
+After=network.target
+
+[Service]
+WorkingDirectory={{ prom_basedir }}
+Restart=on-failure
+ExecStart={{ prom_basedir }}/prom-am-executor -v -l 127.0.0.1:{{ prom_am_executor_port }} {{ prom_basedir }}/restart_iri.sh
+Type=simple
+
+# No need that exporter messes with /dev
+PrivateDevices=yes
+
+# Dedicated /tmp
+PrivateTmp=yes
+
+# Make /usr, /boot, /etc read only
+ProtectSystem=full
+
+# /home is not accessible at all
+ProtectHome=yes
+
+# This service has to be able to issue a systemctl restart.
+# Attempting to use sudoers special rule didn't work out
+# to let an unprivileged user to run a sudo command.
+# That's why the use of user root here.
+User=root
+Group=root
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Due to the problem many full nodes are experiencing where the latest subtangle milestone gets stuck, this alert+handler try to remedy this by restarting IRI.

The executor is disabled by default in alertmanager's configuration.
If the user chooses to make use of it, just has to un-comment the related lines and restart alertmanager.