### PR TITLE
New settings for iri java memory limits, according to systems RAM

### DIFF
--- a/roles/iri/tasks/iri.yml
+++ b/roles/iri/tasks/iri.yml
@@ -14,11 +14,23 @@
     config_dir: /etc/default
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
-- name: set memory limit for java-iri
-  set_fact:
-    iri_java_mem: "{{ (ansible_memtotal_mb * 0.8)|int|abs }}m"
-    iri_init_java_mem: "{{ (ansible_memtotal_mb * 0.2)|int|abs }}m"
-    iri_java_heap_mem: "{{ (ansible_memtotal_mb * 0.2)|int|abs }}m"
+- name: auto memory settings block
+  block:
+
+    - name: set memory limit factor for memory larger than 10240m
+      set_fact:
+        iri_java_mem: 8192m
+        iri_init_java_mem: 2048m
+        iri_java_heap_mem: 2048m
+      when: ansible_memtotal_mb|int > 10240
+
+    - name: set memory limit for java-iri for RAM up to 10240m
+      set_fact:
+        iri_java_mem: "{{ (ansible_memtotal_mb|int * 0.7)|int|abs }}m"
+        iri_init_java_mem: "{{ (ansible_memtotal_mb|int * 0.2)|int|abs }}m"
+        iri_java_heap_mem: "{{ (ansible_memtotal_mb|int * 0.2)|int|abs }}m"
+      when: ansible_memtotal_mb|int <= 10240
+
   when: memory_autoset is defined and memory_autoset
   tags:
     - mem_override


### PR DESCRIPTION
This fixes the situation where on systems with very large memory the limit for IRI/Java is huge. This limits to 8192m which should be more than enough to run IRI with enough neighbors to keep the node efficient.