### PR TITLE
Ubuntu to download java oracle tar rather than repos

### DIFF
--- a/group_vars/all/iri.yml
+++ b/group_vars/all/iri.yml
@@ -44,5 +44,11 @@ iri_remote_limit_api: "removeNeighbors, addNeighbors, interruptAttachingToTangle
 # If set to `false` it will only bind to localhost (127.0.0.1)
 api_port_remote: false
 
-# The version to download, check http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
-oracle_java_url: 'http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jdk-8u162-linux-x64.rpm'
+# The RPM version to download, check http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html
+oracle_java_rpm: 'http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jdk-8u162-linux-x64.rpm'
+
+# The version to download for Ubuntu
+oracle_java_tar: 'http://download.oracle.com/otn-pub/java/jdk/8u162-b12/0da788060d494f5095bf8624735fa2f1/jdk-8u162-linux-x64.tar.gz'
+
+# Java oracle directory
+oracle_java_dir: jdk1.8.0_162

--- a/roles/iri/tasks/deps_apt.yml
+++ b/roles/iri/tasks/deps_apt.yml
@@ -8,27 +8,6 @@
 - name: Install software-properties-common
   apt: state=latest name=software-properties-common update_cache=yes
 
-### Installation via packages disabled due to the chance
-### of Oracle changing links/versions. Update will be
-### faster in the playbook rather than wait for ppa:webupd8team/java
-#- name: apt add repository
-#  apt_repository:
-#    repo: 'ppa:webupd8team/java'
-#    state: present
-
-#- name: debian | ensure the webupd8 launchpad apt repository key is present
-#  apt_key:
-#    id=0xC2518248EEA14886
-#    keyserver=keyserver.ubuntu.com
-#    state=present
-
-#- name: set license as accepted
-#  debconf:
-#    name: 'oracle-java8-installer'
-#    question: 'shared/accepted-oracle-license-v1-1'
-#    value: 'true'
-#    vtype: 'select'
-
 - name: install oracle java
   block:
 
@@ -95,11 +74,9 @@
     - htop
     - pastebinit
 
-#- name: Install oracle-java8-set-default
-#  apt: state=latest name=oracle-java8-set-default update_cache=yes
-
 - name: set java home environment
   lineinfile:
     path: /etc/environment
     regexp: '^JAVA_HOME'
-    line: 'JAVA_HOME="/usr/lib/jvm/java-8-oracle"'
+    line: 'JAVA_HOME="/opt/jdk/{{ oracle_java_dir }}"'
+  when: jdk_downloaded is defined and jdk_downloaded.changed

--- a/roles/iri/tasks/deps_apt.yml
+++ b/roles/iri/tasks/deps_apt.yml
@@ -8,23 +8,76 @@
 - name: Install software-properties-common
   apt: state=latest name=software-properties-common update_cache=yes
 
-- name: apt add repository
-  apt_repository:
-    repo: 'ppa:webupd8team/java'
-    state: present
+### Installation via packages disabled due to the chance
+### of Oracle changing links/versions. Update will be
+### faster in the playbook rather than wait for ppa:webupd8team/java
+#- name: apt add repository
+#  apt_repository:
+#    repo: 'ppa:webupd8team/java'
+#    state: present
 
-- name: debian | ensure the webupd8 launchpad apt repository key is present
-  apt_key:
-    id=0xC2518248EEA14886
-    keyserver=keyserver.ubuntu.com
-    state=present
+#- name: debian | ensure the webupd8 launchpad apt repository key is present
+#  apt_key:
+#    id=0xC2518248EEA14886
+#    keyserver=keyserver.ubuntu.com
+#    state=present
 
-- name: set license as accepted
-  debconf:
-    name: 'oracle-java8-installer'
-    question: 'shared/accepted-oracle-license-v1-1'
-    value: 'true'
-    vtype: 'select'
+#- name: set license as accepted
+#  debconf:
+#    name: 'oracle-java8-installer'
+#    question: 'shared/accepted-oracle-license-v1-1'
+#    value: 'true'
+#    vtype: 'select'
+
+- name: install oracle java
+  block:
+
+    - name: stat oracle java directory
+      stat:
+        path: "/opt/jdk/{{ oracle_java_dir }}"
+      register: oracle_java_dir_stat
+      tags:
+        - oracle_java_tar
+
+    - name: Download java jdk rpm
+      get_url:
+        url: "{{ oracle_java_tar }}"
+        dest: /tmp/jdk.x86_64.tgz
+        headers: 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'
+        validate_certs: no
+        force: yes
+      when: not oracle_java_dir_stat.stat.exists
+      register: jdk_downloaded
+      tags:
+        - download_jdk_tar
+        - oracle_java_tar
+
+    - name: ensure target path for jdk exists
+      file:
+        path: "/opt/jdk"
+        state: directory
+      tags:
+        - oracle_java_tar
+
+    - name: unarchive java tar
+      unarchive:
+        src: /tmp/jdk.x86_64.tgz
+        dest: "/opt/jdk"
+      when: >
+            not oracle_java_dir_stat.stat.exists or
+            (jdk_downloaded and jdk_downloaded.changed)
+      tags:
+        - oracle_java_tar
+
+    - name: set java environment
+      shell: "update-alternatives --install /usr/bin/java java /opt/jdk/{{ oracle_java_dir }}/bin/java 10000"
+      register: java_env
+      changed_when: "java_env.stdout != ''"
+
+    - name: set javac environment
+      shell: "update-alternatives --install /usr/bin/javac javac /opt/jdk/{{ oracle_java_dir }}/bin/javac 10000"
+      register: javac_env
+      changed_when: "javac_env.stdout != ''"
 
 - name: Install some packages
   apt: state=latest name={{ item }} update_cache=yes
@@ -32,7 +85,6 @@
     - maven
     - jq
     - ufw
-    - oracle-java8-installer
     - wget
     - lsof
     - curl
@@ -43,8 +95,8 @@
     - htop
     - pastebinit
 
-- name: Install oracle-java8-set-default
-  apt: state=latest name=oracle-java8-set-default update_cache=yes
+#- name: Install oracle-java8-set-default
+#  apt: state=latest name=oracle-java8-set-default update_cache=yes
 
 - name: set java home environment
   lineinfile:

--- a/roles/iri/tasks/deps_yum.yml
+++ b/roles/iri/tasks/deps_yum.yml
@@ -9,7 +9,7 @@
 
 - name: Download java jdk rpm
   get_url:
-    url: "{{ oracle_java_url }}"
+    url: "{{ oracle_java_rpm }}"
     dest: /tmp/jdk-oracle.x86_64.rpm
     headers: 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'
     validate_certs: no


### PR DESCRIPTION
This is preferable to using the repository because they can take time to update versions when oracle changes links. This way we can maintain it via the playbook.