### PR TITLE
Rate limit iri API port in ufw

### DIFF
--- a/roles/iri/tasks/firewalld.yml
+++ b/roles/iri/tasks/firewalld.yml
@@ -18,9 +18,9 @@
     state: enabled
     immediate: yes
 
-- name: allow iri api port in firewall
+- name: allow and rate limit api port in firewall
   firewalld:
-    port: "{{ iri_api_port }}/tcp"
+    rich_rule: 'rule port port={{ iri_api_port }} protocol=tcp limit value="12/m" accept'
     permanent: true
     state: enabled
     immediate: yes

--- a/roles/iri/tasks/ufw.yml
+++ b/roles/iri/tasks/ufw.yml
@@ -20,6 +20,18 @@
     port: "{{ iri_api_port }}"
   when: api_port_remote is defined and api_port_remote
 
+# ufw supports connection rate limiting, which is useful for protecting
+# against denial of service attacks. ufw will deny connections if an IP
+# address has attempted to initiate 6 or more connections in the last
+# 30 seconds. See  http://www.debian-administration.org/articles/187
+# for details.
+- name: rate limit iri api port in firewall
+  ufw:
+    rule: limit
+    direction: in
+    proto: tcp
+    port: "{{ iri_api_port }}"
+
 - name: allow ssh port firewall
   ufw:
     rule: allow

--- a/roles/iri/tasks/ufw.yml
+++ b/roles/iri/tasks/ufw.yml
@@ -18,6 +18,7 @@
     direction: in
     proto: tcp
     port: "{{ iri_api_port }}"
+    log: yes
   when: api_port_remote is defined and api_port_remote
 
 # ufw supports connection rate limiting, which is useful for protecting
@@ -31,6 +32,7 @@
     direction: in
     proto: tcp
     port: "{{ iri_api_port }}"
+    log: yes
 
 - name: allow ssh port firewall
   ufw:

--- a/roles/iri/tasks/ufw.yml
+++ b/roles/iri/tasks/ufw.yml
@@ -12,27 +12,30 @@
     proto: udp
     port: "{{ iri_udp_port }}"
 
-- name: allow iri api port in firewall
-  ufw:
-    rule: allow
-    direction: in
-    proto: tcp
-    port: "{{ iri_api_port }}"
-    log: yes
-  when: api_port_remote is defined and api_port_remote
+- name: ufw iri port
+  block:
+    - name: allow iri api port in firewall
+      ufw:
+        rule: allow
+        direction: in
+        proto: tcp
+        port: "{{ iri_api_port }}"
+        log: yes
 
-# ufw supports connection rate limiting, which is useful for protecting
-# against denial of service attacks. ufw will deny connections if an IP
-# address has attempted to initiate 6 or more connections in the last
-# 30 seconds. See  http://www.debian-administration.org/articles/187
-# for details.
-- name: rate limit iri api port in firewall
-  ufw:
-    rule: limit
-    direction: in
-    proto: tcp
-    port: "{{ iri_api_port }}"
-    log: yes
+    # ufw supports connection rate limiting, which is useful for protecting
+    # against denial of service attacks. ufw will deny connections if an IP
+    # address has attempted to initiate 6 or more connections in the last
+    # 30 seconds. See  http://www.debian-administration.org/articles/187
+    # for details.
+    - name: rate limit iri api port in firewall
+      ufw:
+        rule: limit
+        direction: in
+        proto: tcp
+        port: "{{ iri_api_port }}"
+        log: yes
+
+  when: api_port_remote is defined and api_port_remote
 
 - name: allow ssh port firewall
   ufw:


### PR DESCRIPTION
Add rate limiting to avoid DDoS attacks on exposed IRI API port.