### PR TITLE
Try copy=no on unarchive task to fix remote installations

### DIFF
--- a/roles/iri/tasks/deps_apt.yml
+++ b/roles/iri/tasks/deps_apt.yml
@@ -42,6 +42,7 @@
       unarchive:
         src: /tmp/jdk.x86_64.tgz
         dest: "/opt/jdk"
+        copy: no
       when: >
             not oracle_java_dir_stat.stat.exists or
             (jdk_downloaded and jdk_downloaded.changed)


### PR DESCRIPTION
Using 'unarchive' module sets copy=yes by default which fails on remote installations as it searches for the package locally.
Setting 'copy: no' allows to use a package on the remote system instead of looking for it locally.