### PR TITLE
Use a single ssl config file for nginx

### DIFF
--- a/docs/appendix.rst
+++ b/docs/appendix.rst
@@ -134,8 +134,7 @@ Your connection will still be encrypted if you opt for a self-signed certificate
 
 Here is a great tutorial on how to add HTTPS to your **nginx**, choose nginx and the OS version you are using (Ubuntu/CentOS):
 
-If you installed using the iri-playbook, make sure you DON'T use the automatic configuration command. Use the ``sudo certbot --nginx certonly`` command and configure the certificates manually.
-
+(For iri-playbook installations you can configure the generated certificate and key in /etc/nginx/conf.d/ssl.cfg)
 
 https://certbot.eff.org/
 

--- a/roles/iotapm/tasks/iotapm.yml
+++ b/roles/iotapm/tasks/iotapm.yml
@@ -58,6 +58,15 @@
     mode: 0755
   when: install_nginx is defined and install_nginx
 
+- name: copy ssl.cfg nginx config
+  template:
+    src: ../shared-files/ssl.cfg.j2
+    dest: /etc/nginx/conf.d/ssl.cfg
+  validate: "/usr/local/bin/validate_nginx_config.sh -t %s -d conf.d/iotapm.conf -r"
+  when: install_nginx is defined and install_nginx
+  notify:
+    - reload nginx
+
 - name: copy iotapm nginx config
   template:
     src: templates/iotapm.conf.j2

--- a/roles/iotapm/templates/iotapm.conf.j2
+++ b/roles/iotapm/templates/iotapm.conf.j2
@@ -10,29 +10,7 @@ server {
     # Redirect same port from http to https
     error_page 497 https://$host:$server_port$request_uri;
 
-    ssl_certificate {{ ssl_cert_file }};
-    ssl_certificate_key {{ ssl_key_file }};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # If you choose to add dhparam, run this command and
-    # remove # from the line beginning with `ssl_dhparam`:
-    # `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
-    #ssl_dhparam /etc/ssl/private/dhparam.pem;
-
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_ecdh_curve secp384r1;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 10s;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    # Replace when valid certificates
-    #ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
-    add_header Strict-Transport-Security max-age=15768000;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/conf.d/ssl.cfg;
 
     auth_basic "Restricted";
     auth_basic_user_file /etc/nginx/.htpasswd;

--- a/roles/monitoring/tasks/prometheus.yml
+++ b/roles/monitoring/tasks/prometheus.yml
@@ -58,6 +58,15 @@
     mode: 0755
   when: install_nginx is defined and install_nginx
 
+- name: copy ssl.cfg nginx config
+  template:
+    src: ../shared-files/ssl.cfg.j2
+    dest: /etc/nginx/conf.d/ssl.cfg
+  validate: "/usr/local/bin/validate_nginx_config.sh -t %s -d conf.d/iotapm.conf -r"
+  when: install_nginx is defined and install_nginx
+  notify:
+    - reload nginx
+
 - name: copy prometheus nginx config
   template:
     src: templates/prometheus.conf.j2

--- a/roles/monitoring/templates/alertmanager.conf.j2
+++ b/roles/monitoring/templates/alertmanager.conf.j2
@@ -10,29 +10,7 @@ server {
     # Redirect same port from http to https
     error_page 497 https://$host:$server_port$request_uri;
 
-    ssl_certificate {{ ssl_cert_file }};
-    ssl_certificate_key {{ ssl_key_file }};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # If you choose to add dhparam, run this command and
-    # remove # from the line beginning with `ssl_dhparam`:
-    # `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
-    #ssl_dhparam /etc/ssl/private/dhparam.pem;
-
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_ecdh_curve secp384r1;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 10s;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    # Replace when valid certificates
-    #ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
-    add_header Strict-Transport-Security max-age=15768000;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/conf.d/ssl.cfg;
 
     auth_basic "Restricted";
     auth_basic_user_file /etc/nginx/.htpasswd;

--- a/roles/monitoring/templates/grafana.conf.j2
+++ b/roles/monitoring/templates/grafana.conf.j2
@@ -10,29 +10,7 @@ server {
     # Redirect same port from http to https
     error_page 497 https://$host:$server_port$request_uri;
 
-    ssl_certificate {{ ssl_cert_file }};
-    ssl_certificate_key {{ ssl_key_file }};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # If you choose to add dhparam, run this command and
-    # remove # from the line beginning with `ssl_dhparam`:
-    # `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
-    #ssl_dhparam /etc/ssl/private/dhparam.pem;
-
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_ecdh_curve secp384r1;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 10s;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    # Replace when valid certificates
-    #ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
-    add_header Strict-Transport-Security max-age=15768000;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/conf.d/ssl.cfg;
 
     #auth_basic "Restricted";
     #auth_basic_user_file /etc/nginx/.htpasswd;

--- a/roles/monitoring/templates/prometheus.conf.j2
+++ b/roles/monitoring/templates/prometheus.conf.j2
@@ -10,29 +10,7 @@ server {
     # Redirect same port from http to https
     error_page 497 https://$host:$server_port$request_uri;
 
-    ssl_certificate {{ ssl_cert_file }};
-    ssl_certificate_key {{ ssl_key_file }};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # If you choose to add dhparam, run this command and
-    # remove # from the line beginning with `ssl_dhparam`:
-    # `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
-    #ssl_dhparam /etc/ssl/private/dhparam.pem;
-
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_ecdh_curve secp384r1;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 10s;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    # Replace when valid certificates
-    #ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
-    add_header Strict-Transport-Security max-age=15768000;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/conf.d/ssl.cfg;
 
     auth_basic "Restricted";
     auth_basic_user_file /etc/nginx/.htpasswd;

--- a/roles/nelson/tasks/proxy-gui.yml
+++ b/roles/nelson/tasks/proxy-gui.yml
@@ -30,6 +30,15 @@
     - iotapm_file.stat.exists == True
     - validation_script.stat.exists == True
 
+- name: copy ssl.cfg nginx config
+  template:
+    src: ../shared-files/ssl.cfg.j2
+    dest: /etc/nginx/conf.d/ssl.cfg
+  validate: "/usr/local/bin/validate_nginx_config.sh -t %s -d conf.d/iotapm.conf -r"
+  when: install_nginx is defined and install_nginx
+  notify:
+    - reload nginx
+
 - name: copy nelson-gui nginx conf file
   template:
     src: templates/nelson-gui.conf.j2

--- a/roles/nelson/templates/nelson-gui.conf.j2
+++ b/roles/nelson/templates/nelson-gui.conf.j2
@@ -10,29 +10,7 @@ server {
     # Redirect same port from http to https
     error_page 497 https://$host:$server_port$request_uri;
 
-    ssl_certificate {{ ssl_cert_file }};
-    ssl_certificate_key {{ ssl_key_file }};
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # If you choose to add dhparam, run this command and
-    # remove # from the line beginning with `ssl_dhparam`:
-    # `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
-    #ssl_dhparam /etc/ssl/private/dhparam.pem;
-
-    ssl_prefer_server_ciphers on;
-    ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:10m;
-    ssl_ecdh_curve secp384r1;
-    resolver 8.8.8.8 8.8.4.4 valid=300s;
-    resolver_timeout 10s;
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    # Replace when valid certificates
-    #ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
-    add_header Strict-Transport-Security max-age=15768000;
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
+    include /etc/nginx/conf.d/ssl.cfg;
 
     # uses own auth
     #auth_basic "Restricted";

--- a/roles/shared-files/ssl.cfg.j2
+++ b/roles/shared-files/ssl.cfg.j2
@@ -1,0 +1,24 @@
+ssl_certificate {{ ssl_cert_file }};
+ssl_certificate_key {{ ssl_key_file }};
+ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+# If you choose to add dhparam, run this command and
+# remove # from the line beginning with `ssl_dhparam`:
+# `cd /etc/ssl/private && openssl dhparam -out dhparam.pem 4096`
+#ssl_dhparam /etc/ssl/private/dhparam.pem;
+
+ssl_prefer_server_ciphers on;
+ssl_ciphers 'AES256+EECDH:AES256+EDH:!aNULL';
+ssl_session_timeout 1d;
+ssl_session_cache shared:SSL:10m;
+ssl_ecdh_curve secp384r1;
+resolver 8.8.8.8 8.8.4.4 valid=300s;
+resolver_timeout 10s;
+ssl_stapling off;
+ssl_stapling_verify off;
+# Replace when valid certificates
+#ssl_trusted_certificate /etc/ssl/certs/bundle-cert.crt;
+add_header Strict-Transport-Security max-age=15768000;
+add_header X-Frame-Options DENY;
+add_header X-Content-Type-Options nosniff;
+

--- a/roles/shared-files/ssl.cfg.j2
+++ b/roles/shared-files/ssl.cfg.j2
@@ -21,4 +21,3 @@ ssl_stapling_verify off;
 add_header Strict-Transport-Security max-age=15768000;
 add_header X-Frame-Options DENY;
 add_header X-Content-Type-Options nosniff;
-


### PR DESCRIPTION
Instead of having the same SSL configuration options in each vhost conf file, include a shared ssl configuration file.