### PR TITLE
Ignore IRI wait for port in iota-pm task

### DIFF
--- a/roles/iotapm/tasks/iotapm.yml
+++ b/roles/iotapm/tasks/iotapm.yml
@@ -87,10 +87,10 @@
   no_log: true
   when: install_nginx is defined and install_nginx
 
-- name: Wait max 600 seconds for IRI API port to become available. This can take a while...
-  wait_for:
-    timeout: 600
-    port: "{{ iri_api_port }}"
+#- name: Wait max 600 seconds for IRI API port to become available. This can take a while...
+#  wait_for:
+#    timeout: 600
+#    port: "{{ iri_api_port }}"
 
 - name: ensure iota-pm started and enabled
   systemd:


### PR DESCRIPTION
Ignore waiting for IRI port