### PR TITLE
Update deps_apt.yml oracle_java_tar headers

### DIFF
--- a/roles/iri/tasks/deps_apt.yml
+++ b/roles/iri/tasks/deps_apt.yml
@@ -22,7 +22,7 @@
       get_url:
         url: "{{ oracle_java_tar }}"
         dest: /tmp/jdk.x86_64.tgz
-        headers: 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie'
+        headers: 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2Ftechnetwork%2Fjava%2Fjavase%2Fdownloads%2Fjdk8-downloads-2133151.html; oraclelicense=accept-securebackup-cookie'
         validate_certs: no
         force: yes
         timeout: 20


### PR DESCRIPTION
Downloading java jdk tar from Oracle raise a fatal error.
Problem can be reproduced in Ubuntu 18.04 LTS

TASK [iri : Download java jdk tar]
fatal: [localhost]: FAILED! => {"changed": false, "dest": "/tmp/jdk.x86_64.tgz", "msg": "Connection failure: timed out", "state": "absent", "url": "http://download.oracle.com/otn-pub/java/jdk/8u172-b11/a58eab1ec242421181065cdc37240b08/jdk-8u172-linux-x64.tar.gz"}

This problem can be solved by changing the 'Cookie' value inside 'headers' variable.