### PR TITLE
Make chown targets work with symlinks

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -196,7 +196,7 @@ You can use the ``iric`` tool to download and install the database :ref:`iric`, 
 
 .. code:: bash
 
-  systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target && wget -O - https://x-vps.com/iota.db.tgz | tar zxv && chown iri.iri /var/lib/iri -R && systemctl start iri
+  systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target && wget -O - https://x-vps.com/iota.db.tgz | tar zxv && chown iri.iri /var/lib/iri/target/ -R && systemctl start iri
 
 .. raw:: html
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -196,7 +196,7 @@ You can use the ``iric`` tool to download and install the database :ref:`iric`, 
 
 .. code:: bash
 
-  systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target && wget -O - https://x-vps.com/iota.db.tgz | tar zxv && chown iri.iri /var/lib/iri/target/ -R && systemctl start iri
+  systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target && wget -O - https://x-vps.com/iota.db.tgz | tar zxv && chown iri.iri /var/lib/iri -RL && systemctl start iri
 
 .. raw:: html
 

--- a/roles/iri/files/iric
+++ b/roles/iri/files/iric
@@ -13,7 +13,7 @@ fi
 clear
 [ -f "$HOME/.iric" ] && . "$HOME/.iric"
 EDITOR="${EDITOR:-nano}"
-VERSION=0.7.12
+VERSION=0.7.13
 CUR_DIR=$(pwd)
 PID_FILE=/var/run/iric.pid
 WIDTH=78

--- a/roles/iri/files/iric
+++ b/roles/iri/files/iric
@@ -672,7 +672,7 @@ function get_db() {
         # This command will stop iri, remove older database directories,
         # extract the database (on the fly) set correct user ownership and start IRI up again.
         echo "Stopping iri first, removing old database files and commencing download/extract of database files ..."
-        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri/target/ -R && systemctl start iri
+        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri/ -RL && systemctl start iri
         if [[ $? -ne 0 ]]; then
             whiptail --title "New DB Failed!" \
                      --msgbox "Well this is embarrassing. Downloading the new DB failed..." \

--- a/roles/iri/files/iric
+++ b/roles/iri/files/iric
@@ -672,7 +672,7 @@ function get_db() {
         # This command will stop iri, remove older database directories,
         # extract the database (on the fly) set correct user ownership and start IRI up again.
         echo "Stopping iri first, removing old database files and commencing download/extract of database files ..."
-        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri/ -RL && systemctl start iri
+        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri -RL && systemctl start iri
         if [[ $? -ne 0 ]]; then
             whiptail --title "New DB Failed!" \
                      --msgbox "Well this is embarrassing. Downloading the new DB failed..." \

--- a/roles/iri/files/iric
+++ b/roles/iri/files/iric
@@ -672,7 +672,7 @@ function get_db() {
         # This command will stop iri, remove older database directories,
         # extract the database (on the fly) set correct user ownership and start IRI up again.
         echo "Stopping iri first, removing old database files and commencing download/extract of database files ..."
-        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri -R && systemctl start iri
+        systemctl stop iri && rm -rf /var/lib/iri/target/{mainnetdb*,mainnet.snapshot*,spent-addresses-*} && mkdir -p /var/lib/iri/target && cd /var/lib/iri/target/ && wget -O - "$DB_SOURCE" | tar zxv && chown iri.iri /var/lib/iri/target/ -R && systemctl start iri
         if [[ $? -ne 0 ]]; then
             whiptail --title "New DB Failed!" \
                      --msgbox "Well this is embarrassing. Downloading the new DB failed..." \

--- a/upgrade-local-snapshots.sh
+++ b/upgrade-local-snapshots.sh
@@ -126,7 +126,7 @@ mkdir /var/lib/iri/target/mainnetdb
 
 cd /var/lib/iri/target
 tar zxvf /tmp/iota.snap.tgz
-chown -R iri.iri /var/lib/iri/target/
+chown -RL iri.iri /var/lib/iri/target
 
 echo "Configuring files ..."
 [ -f "/etc/default/iri" ] && sed -i "s/^IRI_VERSION=.*/IRI_VERSION=$IRI_VERSION/" /etc/default/iri

--- a/upgrade-local-snapshots.sh
+++ b/upgrade-local-snapshots.sh
@@ -126,7 +126,7 @@ mkdir /var/lib/iri/target/mainnetdb
 
 cd /var/lib/iri/target
 tar zxvf /tmp/iota.snap.tgz
-chown -R iri.iri /var/lib/iri/target
+chown -R iri.iri /var/lib/iri/target/
 
 echo "Configuring files ..."
 [ -f "/etc/default/iri" ] && sed -i "s/^IRI_VERSION=.*/IRI_VERSION=$IRI_VERSION/" /etc/default/iri


### PR DESCRIPTION
A couple different places call `chown -R iri.iri /var/lib/iri` but that will do nothing if `/var/lib/iri` is a symlink to another dir. This PR changes the chown path parameter to ` /var/lib/iri/target/` so any symlinks will be dereferenced first.