### PR TITLE
Docker/images syntax

### DIFF
--- a/roles/consul/tasks/config-consul-template.yml
+++ b/roles/consul/tasks/config-consul-template.yml
@@ -1,11 +1,13 @@
 - name: set etc config dir debian/ubuntu
   set_fact:
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: set etc config dir centos
   set_fact:
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: ensure etc haproxy dir
@@ -18,7 +20,7 @@
   stat:
     path: /etc/haproxy/haproxy.cfg
   register: haproxy_file
-  
+
 - name: back up original haproxy.cfg file
   block:
 
@@ -62,7 +64,7 @@
 
 - name: consul-template install
   block:
-  
+
     - name: create consul-template directory
       file:
         path: "{{ consul_template_basedir }}"

--- a/roles/consul/tasks/config.yml
+++ b/roles/consul/tasks/config.yml
@@ -1,11 +1,13 @@
 - name: set variables centos
   set_fact:
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 # If running a cluster of Consul, use default interface's IP

--- a/roles/consul/tasks/image-consul.yml
+++ b/roles/consul/tasks/image-consul.yml
@@ -12,7 +12,7 @@
         name: "{{ consul_image }}"
         tag: "{{ consul_tag }}"
         state: absent
-        force: yes
+        force_absent: yes
 
   when:
     - remove_consul_image is defined
@@ -42,6 +42,7 @@
         path: "{{ tempdir.path }}"
         name: "{{ consul_image }}"
         tag: "{{ consul_tag }}"
+        source: build
       notify:
         - restart consul
 
@@ -75,6 +76,7 @@
         path: "{{ tempdir.path }}"
         name: "{{ consul_image }}"
         tag: "{{ consul_tag }}"
+        source: build
       notify:
         - restart consul
 
@@ -126,6 +128,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/consul/tasks/uninstall.yml
+++ b/roles/consul/tasks/uninstall.yml
@@ -119,8 +119,7 @@
 
 - name: remove consul image
   docker_image:
-    force: yes
+    force_absent: yes
     state: absent
     name: "{{ consul_image }}"
-    tag: "{{ consul_tag }}"
   ignore_errors: yes

--- a/roles/haproxy/tasks/certbot.yml
+++ b/roles/haproxy/tasks/certbot.yml
@@ -11,6 +11,8 @@
   docker_image:
     name: "{{ certbot_image }}"
     tag: "{{ certbot_tag }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   tags:
     - certbot_docker_image
   register: download_image_status

--- a/roles/haproxy/tasks/haproxy.yml
+++ b/roles/haproxy/tasks/haproxy.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /lib/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - import_tasks: image-haproxy.yml

--- a/roles/haproxy/tasks/image-haproxy.yml
+++ b/roles/haproxy/tasks/image-haproxy.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ haproxy_image }}"
     tag: "{{ haproxy_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart haproxy
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ haproxy_image }}"
     tag: "{{ haproxy_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart haproxy
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/haproxy/tasks/uninstall.yml
+++ b/roles/haproxy/tasks/uninstall.yml
@@ -103,10 +103,9 @@
 - name: remove haproxy image
   docker_image:
     state: absent
-    force: yes
+    force_absent: yes
     name: "{{ item.image }}"
-    tag: "{{ item.tag }}"
   ignore_errors: yes
   with_items:
-    - { "image": "{{ haproxy_image }}", "tag": "{{ haproxy_tag }}" }
-    - { "image": "{{ certbot_image }}", "tag": "{{ certbot_tag }}" }
+    - "{{ haproxy_image }}"
+    - "{{ certbot_image }}"

--- a/roles/iotapm/tasks/image-iotapm.yml
+++ b/roles/iotapm/tasks/image-iotapm.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ iotapm_image }}"
     tag: "{{ iotapm_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iota-pm
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ iotapm_image }}"
     tag: "{{ iotapm_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iota-pm
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/iotapm/tasks/iotapm.yml
+++ b/roles/iotapm/tasks/iotapm.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /etc/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: add user to run iota-pm as

--- a/roles/iotapm/tasks/uninstall.yml
+++ b/roles/iotapm/tasks/uninstall.yml
@@ -70,7 +70,6 @@
 - name: remove iotapm image
   docker_image:
     state: absent
-    force: yes
+    force_absent: yes
     name: "{{ iotapm_image }}"
-    tag: "{{ iotapm_tag }}"
   ignore_errors: yes

--- a/roles/iri/tasks/image-iri.yml
+++ b/roles/iri/tasks/image-iri.yml
@@ -10,7 +10,8 @@
   docker_image:
     name: "{{ iri_image }}"
     tag: "{{ iri_download_tag_version }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iri
   register: download_image_status
@@ -27,7 +28,8 @@
   docker_image:
     name: "{{ iri_image }}"
     tag: "{{ iri_download_tag_version }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iri
   register: download_image_status
@@ -38,7 +40,7 @@
         images_from_master is not defined or
         images_from_master|bool == False
 
-- name: remove annoying RELEASE tag!
+- name: remove -RELEASE from tag
   shell: "/usr/bin/docker tag {{ iri_image }}:{{ iri_download_tag_version }} {{ iri_image }}:{{ iri_tag }}"
   when: iri_version is version_compare('1.5.6', '>=')
   changed_when: False
@@ -81,6 +83,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/iri/tasks/iri.yml
+++ b/roles/iri/tasks/iri.yml
@@ -1,6 +1,7 @@
 - name: set iri variables
   set_fact:
     iri_workdir: "{{ iri_basedir }}/target"
+  tags: always
 
 - name: set variables centos
   set_fact:
@@ -9,6 +10,7 @@
   when: ansible_distribution == 'CentOS'
   tags:
     - nbctl_config
+    - always
 
 - name: set variables ubuntu
   set_fact:
@@ -17,6 +19,7 @@
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
   tags:
     - nbctl_config
+    - always
 
 - name: allow IPv4 forwarding in kernel
   sysctl:

--- a/roles/iri/tasks/uninstall.yml
+++ b/roles/iri/tasks/uninstall.yml
@@ -131,7 +131,6 @@
 - name: remove iri image
   docker_image:
     state: absent
-    force: yes
+    force_absent: yes
     name: "{{ iri_image }}"
-    tag: "{{ iri_tag }}"
   ignore_errors: yes

--- a/roles/monitoring/tasks/image-alertmanager.yml
+++ b/roles/monitoring/tasks/image-alertmanager.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ alertmanager_image }}"
     tag: "{{ alertmanager_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart alertmanager
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ alertmanager_image }}"
     tag: "{{ alertmanager_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart alertmanager
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/image-cadvisor.yml
+++ b/roles/monitoring/tasks/image-cadvisor.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ cadvisor_image }}"
     tag: "{{ cadvisor_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart cadvisor
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ cadvisor_image }}"
     tag: "{{ cadvisor_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart cadvisor
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/image-grafana.yml
+++ b/roles/monitoring/tasks/image-grafana.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ grafana_image }}"
     tag: "{{ grafana_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart grafana-server
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ grafana_image }}"
     tag: "{{ grafana_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart grafana-server
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/image-iota-prom-exporter.yml
+++ b/roles/monitoring/tasks/image-iota-prom-exporter.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ iota_prom_exporter_image }}"
     tag: "{{ iota_prom_exporter_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iota-prom-exporter
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ iota_prom_exporter_image }}"
     tag: "{{ iota_prom_exporter_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart iota-prom-exporter
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/image-node-exporter.yml
+++ b/roles/monitoring/tasks/image-node-exporter.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ exporter_image }}"
     tag: "{{ exporter_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart node-exporter
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ exporter_image }}"
     tag: "{{ exporter_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart node-exporter
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/image-prometheus.yml
+++ b/roles/monitoring/tasks/image-prometheus.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ prom_image }}"
     tag: "{{ prom_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart prometheus
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ prom_image }}"
     tag: "{{ prom_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart prometheus
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/monitoring/tasks/iota-prom-exporter.yml
+++ b/roles/monitoring/tasks/iota-prom-exporter.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /lib/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: stat iota-prom-exporter basedir for git updates

--- a/roles/monitoring/tasks/preinstall.yml
+++ b/roles/monitoring/tasks/preinstall.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /lib/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: add user to run prometheus as

--- a/roles/monitoring/tasks/uninstall.yml
+++ b/roles/monitoring/tasks/uninstall.yml
@@ -131,14 +131,13 @@
 - name: 'remove monitoring images...'
   docker_image:
     name: "{{ item.image }}"
-    tag: "{{ item.tag }}"
     state: absent
-    force: yes
+    force_absent: yes
   ignore_errors: yes
   with_items:
-    - { "image": "{{ prom_image }}", "tag": "{{ prom_tag }}" }
-    - { "image": "{{ alertmanager_image }}", "tag": "{{ alertmanager_tag }}" }
-    - { "image": "{{ grafana_image }}", "tag": "{{ grafana_tag }}" }
-    - { "image": "{{ exporter_image }}", "tag": "{{ exporter_tag }}" }
-    - { "image": "{{ iota_prom_exporter_image }}", "tag": "{{ iota_prom_exporter_tag }}" }
-    - { "image": "{{ cadvisor_image }}", "tag": "{{ cadvisor_tag }}" }
+    - "{{ prom_image }}"
+    - "{{ alertmanager_image }}"
+    - "{{ grafana_image }}"
+    - "{{ exporter_image }}"
+    - "{{ iota_prom_exporter_image }}"
+    - "{{ cadvisor_image }}"

--- a/roles/nelson/tasks/image-nelson.yml
+++ b/roles/nelson/tasks/image-nelson.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ nelson_image }}"
     tag: "{{ nelson_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nelson
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ nelson_image }}"
     tag: "{{ nelson_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nelson
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/nelson/tasks/image-nelsongui.yml
+++ b/roles/nelson/tasks/image-nelsongui.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ nelsongui_image }}"
     tag: "{{ nelsongui_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nelson-gui
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ nelsongui_image }}"
     tag: "{{ nelsongui_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nelson-gui
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/nelson/tasks/nelson.yml
+++ b/roles/nelson/tasks/nelson.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /lib/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: add user to run nelson as

--- a/roles/nelson/tasks/uninstall.yml
+++ b/roles/nelson/tasks/uninstall.yml
@@ -94,11 +94,10 @@
 
 - name: 'remove nelson images...'
   docker_image:
-    name: "{{ item.image }}"
-    tag: "{{ item.tag }}"
+    name: "{{ item }}"
     state: absent
-    force: yes
+    force_absent: yes
   ignore_errors: yes
   with_items:
-    - { "image": "{{ nelson_image }}", "tag": "{{ nelson_tag }}" }
-    - { "image": "{{ nelsongui_image }}", "tag": "{{ nelsongui_tag }}" }
+    - "{{ nelson_image }}"
+    - "{{ nelsongui_image }}"

--- a/roles/nginx/tasks/image-nginx.yml
+++ b/roles/nginx/tasks/image-nginx.yml
@@ -2,7 +2,8 @@
   docker_image:
     name: "{{ nginx_image }}"
     tag: "{{ nginx_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nginx
   register: download_image_status
@@ -19,7 +20,8 @@
   docker_image:
     name: "{{ nginx_image }}"
     tag: "{{ nginx_tag }}"
-    force: "{{ force_pull_image | default('no') }}"
+    force_source: "{{ force_pull_image | default('no') }}"
+    source: pull
   notify:
     - restart nginx
   register: download_image_status
@@ -68,6 +70,7 @@
         name: "{{ this_image }}"
         tag: "{{ this_tag }}"
         load_path: "{{ this_file }}"
+        source: load
       when:
         - image_copied.changed
       notify:

--- a/roles/nginx/tasks/nginx.yml
+++ b/roles/nginx/tasks/nginx.yml
@@ -2,12 +2,14 @@
   set_fact:
     systemd_dir: /usr/lib/systemd/system
     config_dir: /etc/sysconfig
+  tags: always
   when: ansible_distribution == 'CentOS'
 
 - name: set variables debian/ubuntu
   set_fact:
     systemd_dir: /etc/systemd/system
     config_dir: /etc/default
+  tags: always
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: add user to run nginx as

--- a/roles/nginx/tasks/uninstall.yml
+++ b/roles/nginx/tasks/uninstall.yml
@@ -26,9 +26,8 @@
 - name: 'remove nginx images...'
   docker_image:
     name: "{{ nginx_image }}"
-    tag: "{{ nginx_tag }}"
     state: absent
-    force: yes
+    force_absent: yes
   ignore_errors: yes
 
 - name: remove playbook related nginx vhosts files


### PR DESCRIPTION
Get rid of these deprecation warnings:
```
 [WARNING]: The value of the "source" option was determined to be "pull". Please set the "source" option explicitly. Autodetection will be removed in Ansible
2.12.

[DEPRECATION WARNING]: Param 'force' is deprecated. See the module docs for more information. This feature will be removed in version 2.12. Deprecation warnings
 can be disabled by setting deprecation_warnings=False in ansible.cfg.
```